### PR TITLE
Fix: check if export_ical is true

### DIFF
--- a/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
+++ b/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
@@ -41,7 +41,7 @@ class GenerateIcalOnCalendarEventSubmitCallback
 
         $calendar = CalendarModel::findById(CalendarEventsModel::findById($dc->id)->pid);
 
-        if (null !== $calendar && $calendar->share_ical) {
+        if (null !== $calendar && $calendar->export_ical && $calendar->share_ical) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendar();
         }


### PR DESCRIPTION
Share_ical könnte true sein, obwohl export_ical false ist. Es sollte daher immer beides geprüft werden.