### PR TITLE
Feature export single events as files

### DIFF
--- a/contao/dca/tl_calendar.php
+++ b/contao/dca/tl_calendar.php
@@ -42,7 +42,7 @@ $GLOBALS['TL_DCA']['tl_calendar']['palettes']['__selector__'] = array_merge(
 
 $GLOBALS['TL_DCA']['tl_calendar']['subpalettes'] = array_merge(
     [
-        'export_ical' => 'ical_alias,ical_prefix,ical_description,ical_export_start,ical_export_end,share_ical',
+        'export_ical' => 'ical_alias,ical_prefix,ical_description,ical_export_start,ical_export_end,share_ical,share_ical_events',
     ],
     $GLOBALS['TL_DCA']['tl_calendar']['subpalettes'],
 );
@@ -61,6 +61,14 @@ $GLOBALS['TL_DCA']['tl_calendar']['fields'] = array_merge(
     ]],
     ['share_ical' => [
         'label' => &$GLOBALS['TL_LANG']['tl_calendar']['share_ical'],
+        'exclude' => true,
+        'filter' => true,
+        'inputType' => 'checkbox',
+        'eval' => ['tl_class' => 'clr m12'],
+        'sql' => "char(1) NOT NULL default ''",
+    ]],
+    ['share_ical_events' => [
+        'label' => &$GLOBALS['TL_LANG']['tl_calendar']['share_ical_events'],
         'exclude' => true,
         'filter' => true,
         'inputType' => 'checkbox',

--- a/contao/dca/tl_calendar.php
+++ b/contao/dca/tl_calendar.php
@@ -64,7 +64,7 @@ $GLOBALS['TL_DCA']['tl_calendar']['fields'] = array_merge(
         'exclude' => true,
         'filter' => true,
         'inputType' => 'checkbox',
-        'eval' => ['tl_class' => 'clr m12'],
+        'eval' => ['tl_class' => 'clr m12', 'submitOnChange' => true],
         'sql' => "char(1) NOT NULL default ''",
     ]],
     ['share_ical_events' => [
@@ -72,7 +72,7 @@ $GLOBALS['TL_DCA']['tl_calendar']['fields'] = array_merge(
         'exclude' => true,
         'filter' => true,
         'inputType' => 'checkbox',
-        'eval' => ['tl_class' => 'clr m12'],
+        'eval' => ['tl_class' => 'clr m12', 'submitOnChange' => true],
         'sql' => "char(1) NOT NULL default ''",
     ]],
     ['ical_alias' => [

--- a/contao/languages/de/tl_calendar.php
+++ b/contao/languages/de/tl_calendar.php
@@ -17,8 +17,11 @@ $GLOBALS['TL_LANG']['tl_calendar']['ical_legend'] = 'iCal Einstellungen';
 $GLOBALS['TL_LANG']['tl_calendar']['export_ical']['0'] = 'iCal Abonnement erstellen';
 $GLOBALS['TL_LANG']['tl_calendar']['export_ical']['1'] = 'Ein iCal Abonnement aus dem Kalender generieren, die über <em>domain.tld/ical/calendar/ical_alias</em> abrufbar ist';
 
-$GLOBALS['TL_LANG']['tl_calendar']['share_ical']['0'] = 'zusätzlich iCal Datei in <em>/share</em>';
+$GLOBALS['TL_LANG']['tl_calendar']['share_ical']['0'] = 'zusätzlich iCal Datei für den Kalender in <em>public/share</em>';
 $GLOBALS['TL_LANG']['tl_calendar']['share_ical']['1'] = 'Zusätzlich zur Route kann der Kalender auch unter <em>domain.tld/share/ical_alias.ics</em> als ics Datei abgerufen werden';
+
+$GLOBALS['TL_LANG']['tl_calendar']['share_ical_events']['0'] = 'zusätzlich iCal Dateien für einzelne Events in <em>public/share</em>';
+$GLOBALS['TL_LANG']['tl_calendar']['share_ical_events']['1'] = 'Zusätzlich zur Route werden einzelne Events des Kalenders auch unter <em>domain.tld/share/alias.ics</em> als ics Datei abgerufen werden';
 
 $GLOBALS['TL_LANG']['tl_calendar']['ical_alias']['0'] = 'Kalender-Alias';
 $GLOBALS['TL_LANG']['tl_calendar']['ical_alias']['1'] = 'Geben Sie einen eindeutigen Namen (ohne Endung) für die ical-Datei an, sie wird veröffentlicht unter <em>domain.tld/share/ical_alias.ics</em>.';

--- a/src/CalendarIcalExporter.php
+++ b/src/CalendarIcalExporter.php
@@ -80,17 +80,14 @@ class CalendarIcalExporter
 
     /**
      * Creates an ics file in the share directory for a given Contao Calendar Event.
-     *
-     * @param CalendarEventsModel $calendarEvent
-     * @return void
      */
     public function exportCalendarEvent(CalendarEventsModel $calendarEvent): void
     {
         $this->createVCalendar($this->objCalendar);
-        
+
         $this->addEventToVcalendar($calendarEvent, $this->vCal);
 
-        $this->saveIcalFile(StringUtil::stripRootDir($this->shareDir), $calendarEvent->alias . '.ics');
+        $this->saveIcalFile(StringUtil::stripRootDir($this->shareDir), $calendarEvent->alias.'.ics');
     }
 
     /**

--- a/src/CalendarIcalExporter.php
+++ b/src/CalendarIcalExporter.php
@@ -90,7 +90,7 @@ class CalendarIcalExporter
         
         $this->addEventToVcalendar($calendarEvent, $this->vCal);
 
-        $this->saveIcalFile(StringUtil::stripRootDir($this->shareDir), $this->objCalendar->ical_alias . '_' . $calendarEvent->alias . '.ics');
+        $this->saveIcalFile(StringUtil::stripRootDir($this->shareDir), $calendarEvent->alias . '.ics');
     }
 
     /**

--- a/src/CalendarIcalExporter.php
+++ b/src/CalendarIcalExporter.php
@@ -79,6 +79,21 @@ class CalendarIcalExporter
     }
 
     /**
+     * Creates an ics file in the share directory for a given Contao Calendar Event.
+     *
+     * @param CalendarEventsModel $calendarEvent
+     * @return void
+     */
+    public function exportCalendarEvent(CalendarEventsModel $calendarEvent): void
+    {
+        $this->createVCalendar($this->objCalendar);
+        
+        $this->addEventToVcalendar($calendarEvent, $this->vCal);
+
+        $this->saveIcalFile(StringUtil::stripRootDir($this->shareDir), $this->objCalendar->ical_alias . '_' . $calendarEvent->alias . '.ics');
+    }
+
+    /**
      * Creates a VCalendar for a given Contao Calendar.
      *
      * @property CalendarModel $objCalendar

--- a/src/Cron/GenerateIcalCron.php
+++ b/src/Cron/GenerateIcalCron.php
@@ -49,9 +49,13 @@ class GenerateIcalCron
         }
 
         foreach ($calendars as $calendar) {
-            // Continue if neither Calender, nor Events are set to be share as file in
-            // public/share.
+            // skip calendar, if neither share_ical nor share_ical_events is true.
             if (!$calendar->share_ical && !$calendar->share_ical_events) {
+                continue;
+            }
+
+            // skip calendar, if protected 
+            if ($calendar->protected) {
                 continue;
             }
 

--- a/src/Cron/GenerateIcalCron.php
+++ b/src/Cron/GenerateIcalCron.php
@@ -17,10 +17,16 @@ declare(strict_types=1);
 namespace Janborg\ContaoIcal\Cron;
 
 use Contao\CalendarModel;
-use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
-use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CalendarEventsModel;
 use Janborg\ContaoIcal\CalendarIcalExporter;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Generates iCal files for calendars and their events on a hourly basis.
+ *
+ */
 
 #[AsCronJob('hourly')]
 class GenerateIcalCron
@@ -34,12 +40,37 @@ class GenerateIcalCron
 
     public function __invoke(): void
     {
-        $calendars = CalendarModel::findBy(['export_ical=?'], [1]);
+        // find all Calendars to be exported
+        $calendars = CalendarModel::findAll(
+            ['export_ical=?'],
+            [true]
+        );
+        
+        if (null === $calendars) {
+            return;
+        }
 
         foreach ($calendars as $calendar) {
-            $calendarExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
 
-            $calendarExporter->exportCalendar();
+            // Continue if neither Calender, nor Events are set to be share as file in public/share.
+            if (!$calendar->share_ical && !$calendar->share_ical_events) {
+                continue;
+            }
+
+            // Export ics for the Calendar in public/share.
+            if ($calendar->share_ical) {
+                $calendarExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
+                $calendarExporter->exportCalendar();
+            }
+
+            // Export ics for each Event in public/share.
+            if ($calendar->share_ical_events) {
+                $events = CalendarEventsModel::findBy('pid', $calendar->id);
+                foreach ($events as $event) {
+                    $eventExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
+                    $eventExporter->exportCalendarEvent($event);
+                }
+            }
         }
     }
 }

--- a/src/Cron/GenerateIcalCron.php
+++ b/src/Cron/GenerateIcalCron.php
@@ -16,18 +16,16 @@ declare(strict_types=1);
 
 namespace Janborg\ContaoIcal\Cron;
 
-use Contao\CalendarModel;
 use Contao\CalendarEventsModel;
-use Janborg\ContaoIcal\CalendarIcalExporter;
-use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CalendarModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Janborg\ContaoIcal\CalendarIcalExporter;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Generates iCal files for calendars and their events on a hourly basis.
- *
  */
-
 #[AsCronJob('hourly')]
 class GenerateIcalCron
 {
@@ -41,18 +39,18 @@ class GenerateIcalCron
     public function __invoke(): void
     {
         // find all Calendars to be exported
-        $calendars = CalendarModel::findAll(
+        $calendars = CalendarModel::findBy(
             ['export_ical=?'],
-            [true]
+            [true],
         );
-        
+
         if (null === $calendars) {
             return;
         }
 
         foreach ($calendars as $calendar) {
-
-            // Continue if neither Calender, nor Events are set to be share as file in public/share.
+            // Continue if neither Calender, nor Events are set to be share as file in
+            // public/share.
             if (!$calendar->share_ical && !$calendar->share_ical_events) {
                 continue;
             }
@@ -66,6 +64,7 @@ class GenerateIcalCron
             // Export ics for each Event in public/share.
             if ($calendar->share_ical_events) {
                 $events = CalendarEventsModel::findBy('pid', $calendar->id);
+
                 foreach ($events as $event) {
                     $eventExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
                     $eventExporter->exportCalendarEvent($event);

--- a/src/Cron/GenerateIcalCron.php
+++ b/src/Cron/GenerateIcalCron.php
@@ -54,7 +54,7 @@ class GenerateIcalCron
                 continue;
             }
 
-            // skip calendar, if protected 
+            // skip calendar, if protected
             if ($calendar->protected) {
                 continue;
             }

--- a/src/Cron/RemoveOldIcalFilesCron.php
+++ b/src/Cron/RemoveOldIcalFilesCron.php
@@ -16,19 +16,18 @@ declare(strict_types=1);
 
 namespace Janborg\ContaoIcal\Cron;
 
-use Contao\File;
-use Contao\System;
-use Contao\StringUtil;
-use Contao\CalendarModel;
 use Contao\CalendarEventsModel;
-use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CalendarModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\File;
+use Contao\StringUtil;
+use Contao\System;
 
 /**
- * Removes iCal files for calendars and events that do not exist or are not exported or shared anymore on a hourly basis.
- *
+ * Removes iCal files for calendars and events that do not exist or are not
+ * exported or shared anymore on a hourly basis.
  */
-
 #[AsCronJob('hourly')]
 class RemoveOldIcalFilesCron
 {
@@ -49,7 +48,7 @@ class RemoveOldIcalFilesCron
 
             $objFile = new File(StringUtil::stripRootDir($shareDir).$file);
 
-            $calendar = CalendarModel::findByIcal_alias($objFile->filename);
+            $calendar = CalendarModel::findBy(['ical_alias=?'], [$objFile->filename]);
 
             $calendarEvent = CalendarEventsModel::findByAlias($objFile->filename);
 
@@ -58,33 +57,31 @@ class RemoveOldIcalFilesCron
                 continue;
             }
 
-            // delete file if neither $calendar nor calendarEvent exists with alias = filename 
+            // delete file if neither $calendar nor calendarEvent exists with alias = filename
             if (null === $calendar && null === $calendarEvent) {
                 $objFile->delete();
                 // TODO: use DI
                 System::getContainer()->get('monolog.logger.contao.cron')->info('Verwaiste Ical Datei "'.$objFile->path.'" gelöscht');
                 continue;
-            }    
+            }
 
-            // keep file, if it is linked to any calendar with export_ical = true, ical_share = true and ical_alias = filename
+            // keep file, if it is linked to any calendar with export_ical = true, ical_share
+            // = true and ical_alias = filename @phpstan-ignore-next-line
+            if (null !== $calendar && $calendar->export_ical && $calendar->share_ical) {
+                continue;
+            }
+
+            // keep file, if it is linked to any calendarEvent with alias = filename and
+            // calendar has export_ical = true and ical_share = true
+            $parentCalendar = CalendarModel::findById($calendarEvent->pid);
             if (
-                null !== $calendar &&
-                $calendar->export_ical && 
-                $calendar->share_ical
+                null !== $calendarEvent
+                && null !== $parentCalendar
+                && $parentCalendar->export_ical
+                && $parentCalendar->share_ical_events
+                // TODO: delete calendarEvents from the past (parameter?!)
             ) {
                 continue;
-            }           
-            
-            // keep file, if it is linked to any calendarEvent with alias = filename and calendar has export_ical = true and ical_share = true 
-            $parentCalendar = CalendarModel::findByPk($calendarEvent->pid);
-            if (
-                null !== $calendarEvent &&
-                null !== $parentCalendar &&
-                $parentCalendar->export_ical && 
-                $parentCalendar->share_ical_events
-                // TODO: delete calendarEvents from the past (parameter?!)
-            ) { 
-                continue;                
             }
 
             $objFile->delete();

--- a/src/Cron/RemoveOldIcalFilesCron.php
+++ b/src/Cron/RemoveOldIcalFilesCron.php
@@ -65,7 +65,7 @@ class RemoveOldIcalFilesCron
                 continue;
             }
 
-            // delete file if calendar is protected
+            // delete file if calendar is protected @phpstan-ignore-next-line
             if (null !== $calendar && $calendar->protected) {
                 $objFile->delete();
                 // TODO: use DI
@@ -73,16 +73,17 @@ class RemoveOldIcalFilesCron
                 continue;
             }
 
-            // keep file, if it is linked to any not protected calendar with export_ical = true, ical_share
-            // = true and ical_alias = filename @phpstan-ignore-next-line
+            // keep file, if it is linked to any not protected calendar with export_ical =
+            // true, ical_share = true and ical_alias = filename @phpstan-ignore-next-line
             if (null !== $calendar && $calendar->export_ical && $calendar->share_ical) {
                 continue;
             }
 
-            // keep file, if it is linked to any not protected calendarEvent with alias = filename and
-            // calendar has export_ical = true and ical_share = true
+            // keep file, if it is linked to any not protected calendarEvent with alias =
+            // filename and calendar has export_ical = true and ical_share = true
             $parentCalendar = CalendarModel::findById($calendarEvent->pid);
-            if (null !== $calendarEvent && null !== $parentCalendar && $parentCalendar->export_ical && !$parentCalendar->share_ical_events
+            if (
+                null !== $calendarEvent && null !== $parentCalendar && $parentCalendar->export_ical && !$parentCalendar->share_ical_events
                 // TODO: delete calendarEvents from the past (parameter?!)
             ) {
                 continue;

--- a/src/Cron/RemoveOldIcalFilesCron.php
+++ b/src/Cron/RemoveOldIcalFilesCron.php
@@ -65,20 +65,24 @@ class RemoveOldIcalFilesCron
                 continue;
             }
 
-            // keep file, if it is linked to any calendar with export_ical = true, ical_share
+            // delete file if calendar is protected
+            if (null !== $calendar && $calendar->protected) {
+                $objFile->delete();
+                // TODO: use DI
+                System::getContainer()->get('monolog.logger.contao.cron')->info('Ical Datei "'.$objFile->path.'" gelöscht, da Calendar geschützt ist');
+                continue;
+            }
+
+            // keep file, if it is linked to any not protected calendar with export_ical = true, ical_share
             // = true and ical_alias = filename @phpstan-ignore-next-line
             if (null !== $calendar && $calendar->export_ical && $calendar->share_ical) {
                 continue;
             }
 
-            // keep file, if it is linked to any calendarEvent with alias = filename and
+            // keep file, if it is linked to any not protected calendarEvent with alias = filename and
             // calendar has export_ical = true and ical_share = true
             $parentCalendar = CalendarModel::findById($calendarEvent->pid);
-            if (
-                null !== $calendarEvent
-                && null !== $parentCalendar
-                && $parentCalendar->export_ical
-                && $parentCalendar->share_ical_events
+            if (null !== $calendarEvent && null !== $parentCalendar && $parentCalendar->export_ical && !$parentCalendar->share_ical_events
                 // TODO: delete calendarEvents from the past (parameter?!)
             ) {
                 continue;

--- a/src/Cron/RemoveOldIcalFilesCron.php
+++ b/src/Cron/RemoveOldIcalFilesCron.php
@@ -53,7 +53,7 @@ class RemoveOldIcalFilesCron
 
             $calendarEvent = CalendarEventsModel::findByAlias($objFile->filename);
 
-            // check if file_extension is 'ics'
+            // keep files with extensions, other than ics
             if ('ics' !== $objFile->extension) {
                 continue;
             }
@@ -66,23 +66,23 @@ class RemoveOldIcalFilesCron
                 continue;
             }    
 
-            // ckeck if file is not linked to any calendar with export_ical = true, ical_share = true and ical_alias = filename
+            // keep file, if it is linked to any calendar with export_ical = true, ical_share = true and ical_alias = filename
             if (
                 null !== $calendar &&
                 $calendar->export_ical && 
                 $calendar->share_ical
             ) {
                 continue;
-            }
+            }           
             
-            
-            // check if file is not linked to any calendarEvent with alias = filename and calendar has export_ical = true and ical_share = true 
+            // keep file, if it is linked to any calendarEvent with alias = filename and calendar has export_ical = true and ical_share = true 
             $parentCalendar = CalendarModel::findByPk($calendarEvent->pid);
             if (
                 null !== $calendarEvent &&
                 null !== $parentCalendar &&
                 $parentCalendar->export_ical && 
                 $parentCalendar->share_ical_events
+                // TODO: delete calendarEvents from the past (parameter?!)
             ) { 
                 continue;                
             }

--- a/src/Cron/RemoveOldIcalFilesCron.php
+++ b/src/Cron/RemoveOldIcalFilesCron.php
@@ -24,6 +24,11 @@ use Contao\CalendarEventsModel;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 
+/**
+ * Removes iCal files for calendars and events that do not exist or are not exported or shared anymore on a hourly basis.
+ *
+ */
+
 #[AsCronJob('hourly')]
 class RemoveOldIcalFilesCron
 {
@@ -70,8 +75,9 @@ class RemoveOldIcalFilesCron
                 continue;
             }
             
-            $parentCalendar = CalendarModel::findByPk($calendarEvent->pid);
+            
             // check if file is not linked to any calendarEvent with alias = filename and calendar has export_ical = true and ical_share = true 
+            $parentCalendar = CalendarModel::findByPk($calendarEvent->pid);
             if (
                 null !== $calendarEvent &&
                 null !== $parentCalendar &&

--- a/src/Cron/RemoveOldIcalFilesCron.php
+++ b/src/Cron/RemoveOldIcalFilesCron.php
@@ -16,12 +16,13 @@ declare(strict_types=1);
 
 namespace Janborg\ContaoIcal\Cron;
 
-use Contao\CalendarModel;
-use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
-use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\File;
-use Contao\StringUtil;
 use Contao\System;
+use Contao\StringUtil;
+use Contao\CalendarModel;
+use Contao\CalendarEventsModel;
+use Contao\CoreBundle\Framework\ContaoFramework;
+use Contao\CoreBundle\DependencyInjection\Attribute\AsCronJob;
 
 #[AsCronJob('hourly')]
 class RemoveOldIcalFilesCron
@@ -33,7 +34,7 @@ class RemoveOldIcalFilesCron
 
     public function __invoke(): void
     {
-        $shareDir = System::getContainer()->getParameter('contao.web_dir').'/share/';
+        $shareDir = System::getContainer()->getParameter('contao.web_dir').'/share/'; // TODO: use DI
 
         // Delete old files
         foreach (scandir($shareDir) as $file) {
@@ -43,17 +44,46 @@ class RemoveOldIcalFilesCron
 
             $objFile = new File(StringUtil::stripRootDir($shareDir).$file);
 
-            if (
-                null === CalendarModel::findBy(
-                    ['export_ical = ?', 'ical_alias = ?'],
-                    [true, $objFile->filename],
-                )
-                && 'ics' === $objFile->extension
-            ) {
-                $objFile->delete();
+            $calendar = CalendarModel::findByIcal_alias($objFile->filename);
 
-                System::getContainer()->get('monolog.logger.contao.cron')->info('Verwaiste Ical Datei "'.$objFile->path.'" gelöscht');
+            $calendarEvent = CalendarEventsModel::findByAlias($objFile->filename);
+
+            // check if file_extension is 'ics'
+            if ('ics' !== $objFile->extension) {
+                continue;
             }
+
+            // delete file if neither $calendar nor calendarEvent exists with alias = filename 
+            if (null === $calendar && null === $calendarEvent) {
+                $objFile->delete();
+                // TODO: use DI
+                System::getContainer()->get('monolog.logger.contao.cron')->info('Verwaiste Ical Datei "'.$objFile->path.'" gelöscht');
+                continue;
+            }    
+
+            // ckeck if file is not linked to any calendar with export_ical = true, ical_share = true and ical_alias = filename
+            if (
+                null !== $calendar &&
+                $calendar->export_ical && 
+                $calendar->share_ical
+            ) {
+                continue;
+            }
+            
+            $parentCalendar = CalendarModel::findByPk($calendarEvent->pid);
+            // check if file is not linked to any calendarEvent with alias = filename and calendar has export_ical = true and ical_share = true 
+            if (
+                null !== $calendarEvent &&
+                null !== $parentCalendar &&
+                $parentCalendar->export_ical && 
+                $parentCalendar->share_ical_events
+            ) { 
+                continue;                
+            }
+
+            $objFile->delete();
+            // TODO: use DI
+            System::getContainer()->get('monolog.logger.contao.cron')->info('Verwaiste Ical Datei "'.$objFile->path.'" gelöscht');
         }
     }
 }

--- a/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
+++ b/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
@@ -43,20 +43,20 @@ class GenerateIcalOnCalendarEventSubmitCallback
         $calendar = CalendarModel::findById($calendarEvent->pid);
 
         if (
-            null !== $calendar && 
-            $calendar->export_ical && 
-            $calendar->share_ical &&
-            !$calendar->protected
+            null !== $calendar
+            && $calendar->export_ical
+            && $calendar->share_ical
+            && !$calendar->protected
         ) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendar();
         }
 
         if (
-            null !== $calendar && 
-            $calendar->export_ical && 
-            $calendar->share_ical_events &&
-            !$calendar->protected
+            null !== $calendar
+            && $calendar->export_ical
+            && $calendar->share_ical_events
+            && !$calendar->protected
         ) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendarEvent($calendarEvent);

--- a/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
+++ b/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
@@ -20,6 +20,7 @@ use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
+use Contao\Message;
 use Janborg\ContaoIcal\CalendarIcalExporter;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -42,6 +43,12 @@ class GenerateIcalOnCalendarEventSubmitCallback
         $calendarEvent = CalendarEventsModel::findById($dc->id);
         $calendar = CalendarModel::findById($calendarEvent->pid);
 
+        if (null !== $calendar && $calendar->protected) {
+            Message::addError('Der Kalender ist geschützt und kann daher nicht exportiert werden.');
+
+            return;
+        }
+
         if (
             null !== $calendar
             && $calendar->export_ical
@@ -50,6 +57,7 @@ class GenerateIcalOnCalendarEventSubmitCallback
         ) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendar();
+            Message::addInfo('Kalender als ics-Datei unter /public/share/ abgelegt.');
         }
 
         if (
@@ -60,6 +68,7 @@ class GenerateIcalOnCalendarEventSubmitCallback
         ) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendarEvent($calendarEvent);
+            Message::addInfo('Event als ics-Datei unter /public/share/ abgelegt.');
         }
     }
 }

--- a/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
+++ b/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
@@ -39,11 +39,17 @@ class GenerateIcalOnCalendarEventSubmitCallback
             return;
         }
 
-        $calendar = CalendarModel::findById(CalendarEventsModel::findById($dc->id)->pid);
+        $calendarEvent = CalendarEventsModel::findById($dc->id);
+        $calendar = CalendarModel::findById($calendarEvent->pid);
 
         if (null !== $calendar && $calendar->export_ical && $calendar->share_ical) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendar();
+        }
+
+        if (null !== $calendar && $calendar->export_ical && $calendar->share_ical_events) {
+            $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
+            $calenderExporter->exportCalendarEvent($calendarEvent);
         }
     }
 }

--- a/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
+++ b/src/EventListener/DataContainer/GenerateIcalOnCalendarEventSubmitCallback.php
@@ -42,12 +42,22 @@ class GenerateIcalOnCalendarEventSubmitCallback
         $calendarEvent = CalendarEventsModel::findById($dc->id);
         $calendar = CalendarModel::findById($calendarEvent->pid);
 
-        if (null !== $calendar && $calendar->export_ical && $calendar->share_ical) {
+        if (
+            null !== $calendar && 
+            $calendar->export_ical && 
+            $calendar->share_ical &&
+            !$calendar->protected
+        ) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendar();
         }
 
-        if (null !== $calendar && $calendar->export_ical && $calendar->share_ical_events) {
+        if (
+            null !== $calendar && 
+            $calendar->export_ical && 
+            $calendar->share_ical_events &&
+            !$calendar->protected
+        ) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendarEvent($calendarEvent);
         }

--- a/src/EventListener/DataContainer/GenerateIcalOnCalendarSubmitCallback.php
+++ b/src/EventListener/DataContainer/GenerateIcalOnCalendarSubmitCallback.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Janborg\ContaoIcal\EventListener\DataContainer;
 
+use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
@@ -43,7 +44,19 @@ class GenerateIcalOnCalendarSubmitCallback
         if ($calendar->export_ical && $calendar->share_ical) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendar();
-        } else {
+
+            if ($calendar->share_ical_events) {
+                $calendarEvents = CalendarEventsModel::findByPid($dc->id);
+
+                if (null !== $calendarEvents) {
+                    foreach ($calendarEvents as $calendarEvent) {
+                        $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
+                        $calenderExporter->exportCalendarEvent($calendarEvent);
+                    }
+                }
+            }
+        } else { 
+            // elseif share_ical_events ?!
             return;
         }
     }

--- a/src/EventListener/DataContainer/GenerateIcalOnCalendarSubmitCallback.php
+++ b/src/EventListener/DataContainer/GenerateIcalOnCalendarSubmitCallback.php
@@ -20,6 +20,7 @@ use Contao\CalendarEventsModel;
 use Contao\CalendarModel;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
+use Contao\Message;
 use Janborg\ContaoIcal\CalendarIcalExporter;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -41,8 +42,14 @@ class GenerateIcalOnCalendarSubmitCallback
 
         $calendar = CalendarModel::findById($dc->id);
 
+        if (null !== $calendar && $calendar->protected) {
+            Message::addError('Der Kalender ist geschützt und kann daher nicht exportiert werden.');
+
+            return;
+        }
+
         // only proceed if ical export is enabled and not protected
-        if (!$calendar->export_ical || $calendar->protected) {
+        if (!$calendar->export_ical) {
             return;
         }
 
@@ -50,6 +57,7 @@ class GenerateIcalOnCalendarSubmitCallback
         if ($calendar->share_ical) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendar();
+            Message::addInfo('Kalender als ics-Datei unter /public/share/ abgelegt.');
         }
 
         // create ical file for each event if enabled
@@ -60,6 +68,7 @@ class GenerateIcalOnCalendarSubmitCallback
                 foreach ($calendarEvents as $calendarEvent) {
                     $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
                     $calenderExporter->exportCalendarEvent($calendarEvent);
+                    Message::addInfo('Events als einzelne ics-Dateien unter /public/share/ abgelegt.');
                 }
             }
         }

--- a/src/EventListener/DataContainer/GenerateIcalOnCalendarSubmitCallback.php
+++ b/src/EventListener/DataContainer/GenerateIcalOnCalendarSubmitCallback.php
@@ -41,8 +41,8 @@ class GenerateIcalOnCalendarSubmitCallback
 
         $calendar = CalendarModel::findById($dc->id);
 
-        // only proceed if ical export is enabled for this calendar
-        if (!$calendar->export_ical) {
+        // only proceed if ical export is enabled and not protected
+        if (!$calendar->export_ical || $calendar->protected) {
             return;
         }
 

--- a/src/EventListener/DataContainer/GenerateIcalOnCalendarSubmitCallback.php
+++ b/src/EventListener/DataContainer/GenerateIcalOnCalendarSubmitCallback.php
@@ -41,23 +41,27 @@ class GenerateIcalOnCalendarSubmitCallback
 
         $calendar = CalendarModel::findById($dc->id);
 
-        if ($calendar->export_ical && $calendar->share_ical) {
+        // only proceed if ical export is enabled for this calendar
+        if (!$calendar->export_ical) {
+            return;
+        }
+
+        // create ical file for calendar if enabled
+        if ($calendar->share_ical) {
             $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
             $calenderExporter->exportCalendar();
+        }
 
-            if ($calendar->share_ical_events) {
-                $calendarEvents = CalendarEventsModel::findByPid($dc->id);
+        // create ical file for each event if enabled
+        if ($calendar->share_ical_events) {
+            $calendarEvents = CalendarEventsModel::findByPid($dc->id);
 
-                if (null !== $calendarEvents) {
-                    foreach ($calendarEvents as $calendarEvent) {
-                        $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
-                        $calenderExporter->exportCalendarEvent($calendarEvent);
-                    }
+            if (null !== $calendarEvents) {
+                foreach ($calendarEvents as $calendarEvent) {
+                    $calenderExporter = new CalendarIcalExporter($calendar, $this->eventDispatcher);
+                    $calenderExporter->exportCalendarEvent($calendarEvent);
                 }
             }
-        } else { 
-            // elseif share_ical_events ?!
-            return;
         }
     }
 }


### PR DESCRIPTION
See #37 

-     zusätzliche Checkbox im Kalender
-     Anlegen einer ics-Datei beim Speichern eines Events
-     Anlegen der ics-Dateien beim Speichern des Kalenders
-     Anlegen der ics -Dateien stündlch per Cron
-     Löschen von überflüssigen ics-Dateien stündlich per Cron
-     ics-Dateien werden immer unter public/share/<alias>.ics gespeichert
