### PR TITLE
Fix: ContainerAwareInterface was removed in Symfony 6

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,10 +11,6 @@ services:
             calls:
                 - ['setContainer', ['@Psr\Container\ContainerInterface']]
 
-        Symfony\Component\DependencyInjection\ContainerAwareInterface:
-            calls:
-                - ['setContainer', ['@service_container']]
-
     Janborg\ContaoIcal\Cron\GenerateIcalCron:
         arguments:
             - '@contao.framework'


### PR DESCRIPTION
Fixes #51