### PR TITLE
Fix calendar response Content-Disposition filename

### DIFF
--- a/src/Response/CalendarResponse.php
+++ b/src/Response/CalendarResponse.php
@@ -71,7 +71,7 @@ class CalendarResponse extends Response
         $headers['Content-Type'] = \sprintf('%s; charset=utf-8', $mimeType);
 
         $filename = $this->filename.'.ics';
-        $headers['Content-Disposition'] = \sprintf('attachment; filename="%s', $filename);
+        $headers['Content-Disposition'] = \sprintf('attachment; filename="%s"', $filename);
 
         return $headers;
     }

--- a/tests/Response/CalendarResponseTest.php
+++ b/tests/Response/CalendarResponseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of contao-ical-bundle.
+ *
+ * (c) Jan Lünborg 2022 <jan-github@luenborg.eu>
+ *
+ * @license MIT
+ * For the full copyright and license information,
+ * please view the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/janborg/contao-ical-bundle
+ */
+
+namespace Janborg\ContaoIcal\Tests\Response;
+
+use Janborg\ContaoIcal\Response\CalendarResponse;
+use Kigkonsult\Icalcreator\Vcalendar;
+use PHPUnit\Framework\TestCase;
+
+class CalendarResponseTest extends TestCase
+{
+    public function testCreatesCalendarResponseWithExpectedContentAndContentType(): void
+    {
+        $calendar = new Vcalendar();
+        $calendar->setMethod(Vcalendar::PUBLISH);
+
+        $response = new CalendarResponse($calendar, 'team-events');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/calendar; charset=utf-8', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('BEGIN:VCALENDAR', $response->getContent());
+        $this->assertStringContainsString('METHOD:PUBLISH', $response->getContent());
+        $this->assertStringContainsString('END:VCALENDAR', $response->getContent());
+    }
+
+    public function testUsesQuotedIcsFilenameInContentDispositionHeader(): void
+    {
+        $response = new CalendarResponse(new Vcalendar(), 'team-events');
+
+        $this->assertSame('attachment; filename="team-events.ics"', $response->headers->get('Content-Disposition'));
+    }
+}


### PR DESCRIPTION
## Summary

- Correct the missing closing quote in the calendar download filename header
- Add response tests covering calendar content, content type, and quoted `.ics` filenames

## Testing

- Added PHPUnit coverage for `CalendarResponse` headers and generated content
- Not run (not requested)